### PR TITLE
wip

### DIFF
--- a/ast/document.go
+++ b/ast/document.go
@@ -26,9 +26,10 @@ func (d *SchemaDocument) Merge(other *SchemaDocument) {
 }
 
 type Schema struct {
-	Query        *Definition
-	Mutation     *Definition
-	Subscription *Definition
+	Query            *Definition
+	Mutation         *Definition
+	Subscription     *Definition
+	SchemaDirectives DirectiveList
 
 	Types      map[string]*Definition
 	Directives map[string]*DirectiveDefinition

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -122,6 +122,10 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 				schema.Subscription = def
 			}
 		}
+		if err := validateDirectives(&schema, sd.Schema[0].Directives, LocationSchema, nil); err != nil {
+			return nil, err
+		}
+		schema.SchemaDirectives = append(schema.SchemaDirectives, sd.Schema[0].Directives...)
 	}
 
 	for _, ext := range sd.SchemaExtension {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -139,6 +139,10 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 				schema.Subscription = def
 			}
 		}
+		if err := validateDirectives(&schema, ext.Directives, LocationSchema, nil); err != nil {
+			return nil, err
+		}
+		schema.SchemaDirectives = append(schema.SchemaDirectives, ext.Directives...)
 	}
 
 	if err := validateTypeDefinitions(&schema); err != nil {

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -71,6 +71,8 @@ func TestLoadSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "Subscription", s.Subscription.Name)
+		require.Equal(t, 1, len(s.SchemaDirectives))
+		require.Equal(t, "authorization", s.SchemaDirectives[0].Name)
 		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
 
 		require.Equal(t, "owner", s.Types["Dog"].Fields[1].Name)

--- a/validator/testdata/extensions.graphql
+++ b/validator/testdata/extensions.graphql
@@ -2,9 +2,11 @@ schema {
     query: Query
 }
 
-extend schema {
+extend schema @authorization(allowedRoles: ["admin"]) {
     subscription: Subscription
 }
+
+directive @authorization(allowedRoles: [String!]!) on SCHEMA
 
 type Query {
     dogs: [Dog!]!


### PR DESCRIPTION
This enables gqlparser to support directive on the schema, which is defined GQL spec. See [#260](https://github.com/vektah/gqlparser/issues/260)

I have:
 - [x] Added tests covering the bug / feature 
 - N/A Updated any relevant documentation
