### PR TITLE
Supporting directive on the schema

### DIFF
--- a/ast/document.go
+++ b/ast/document.go
@@ -26,9 +26,10 @@ func (d *SchemaDocument) Merge(other *SchemaDocument) {
 }
 
 type Schema struct {
-	Query        *Definition
-	Mutation     *Definition
-	Subscription *Definition
+	Query            *Definition
+	Mutation         *Definition
+	Subscription     *Definition
+	SchemaDirectives DirectiveList
 
 	Types      map[string]*Definition
 	Directives map[string]*DirectiveDefinition

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -122,6 +122,10 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 				schema.Subscription = def
 			}
 		}
+		if err := validateDirectives(&schema, sd.Schema[0].Directives, LocationSchema, nil); err != nil {
+			return nil, err
+		}
+		schema.SchemaDirectives = append(schema.SchemaDirectives, sd.Schema[0].Directives...)
 	}
 
 	for _, ext := range sd.SchemaExtension {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -143,6 +143,10 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 				schema.Subscription = def
 			}
 		}
+		if err := validateDirectives(&schema, ext.Directives, LocationSchema, nil); err != nil {
+			return nil, err
+		}
+		schema.SchemaDirectives = append(schema.SchemaDirectives, ext.Directives...)
 	}
 
 	if err := validateTypeDefinitions(&schema); err != nil {

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -71,6 +71,8 @@ func TestLoadSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "Subscription", s.Subscription.Name)
+		require.Equal(t, 1, len(s.SchemaDirectives))
+		require.Equal(t, "authorization", s.SchemaDirectives[0].Name)
 		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
 
 		require.Equal(t, "owner", s.Types["Dog"].Fields[1].Name)

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -71,12 +71,13 @@ func TestLoadSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "Subscription", s.Subscription.Name)
+		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
+
 		require.Equal(t, 1, len(s.SchemaDirectives))
 		require.Equal(t, "exampleOnSchemaDirective", s.SchemaDirectives[0].Name)
 		require.Equal(t, 1, len(s.SchemaDirectives[0].Arguments))
 		require.Equal(t, "name", s.SchemaDirectives[0].Arguments[0].Name)
 		require.Equal(t, "foo", s.SchemaDirectives[0].Arguments[0].Value.Raw)
-		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
 
 		require.Equal(t, "owner", s.Types["Dog"].Fields[1].Name)
 

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -72,7 +72,7 @@ func TestLoadSchema(t *testing.T) {
 
 		require.Equal(t, "Subscription", s.Subscription.Name)
 		require.Equal(t, 1, len(s.SchemaDirectives))
-		require.Equal(t, "authorization", s.SchemaDirectives[0].Name)
+		require.Equal(t, "exampleOnSchemaDirective", s.SchemaDirectives[0].Name)
 		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
 
 		require.Equal(t, "owner", s.Types["Dog"].Fields[1].Name)

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -73,6 +73,9 @@ func TestLoadSchema(t *testing.T) {
 		require.Equal(t, "Subscription", s.Subscription.Name)
 		require.Equal(t, 1, len(s.SchemaDirectives))
 		require.Equal(t, "exampleOnSchemaDirective", s.SchemaDirectives[0].Name)
+		require.Equal(t, 1, len(s.SchemaDirectives[0].Arguments))
+		require.Equal(t, "name", s.SchemaDirectives[0].Arguments[0].Name)
+		require.Equal(t, "foo", s.SchemaDirectives[0].Arguments[0].Value.Raw)
 		require.Equal(t, "dogEvents", s.Subscription.Fields[0].Name)
 
 		require.Equal(t, "owner", s.Types["Dog"].Fields[1].Name)

--- a/validator/testdata/extensions.graphql
+++ b/validator/testdata/extensions.graphql
@@ -2,9 +2,11 @@ schema {
     query: Query
 }
 
-extend schema {
+extend schema @authorization(allowedRoles: ["admin"]) {
     subscription: Subscription
 }
+
+directive @authorization(allowedRoles: [String!]!) on SCHEMA
 
 type Query {
     dogs: [Dog!]!

--- a/validator/testdata/extensions.graphql
+++ b/validator/testdata/extensions.graphql
@@ -2,11 +2,11 @@ schema {
     query: Query
 }
 
-extend schema @exampleOnSchemaDirective(name: ["foo"]) {
+extend schema @exampleOnSchemaDirective(name: "foo") {
     subscription: Subscription
 }
 
-directive @exampleOnSchemaDirective(name: [String!]!) on SCHEMA
+directive @exampleOnSchemaDirective(name: String!) on SCHEMA
 
 type Query {
     dogs: [Dog!]!

--- a/validator/testdata/extensions.graphql
+++ b/validator/testdata/extensions.graphql
@@ -2,11 +2,11 @@ schema {
     query: Query
 }
 
-extend schema @authorization(allowedRoles: ["admin"]) {
+extend schema @exampleOnSchemaDirective(name: ["foo"]) {
     subscription: Subscription
 }
 
-directive @authorization(allowedRoles: [String!]!) on SCHEMA
+directive @exampleOnSchemaDirective(name: [String!]!) on SCHEMA
 
 type Query {
     dogs: [Dog!]!


### PR DESCRIPTION
This enables gqlparser to support directives on a schema, which is a part of the GraphQL specification. This fixes [#260](https://github.com/vektah/gqlparser/issues/260)

I have:
 - [x] Added tests covering the bug / feature 
 - N/A Updated any relevant documentation
